### PR TITLE
new chefs page layout

### DIFF
--- a/_layouts/service.html
+++ b/_layouts/service.html
@@ -16,174 +16,190 @@ layout: default
         {% endif %}
       </div> <br>
       {{ page.description }}
+      {% if page.descriptionLinks  %}
+        <ul class="description-links">
+          {% for links in page.descriptionLinks %}
+          <li>
+          <a href="{{ links.link.url }}">{{ links.link.text }}</a>
+          </li>
+          {% endfor %}
+        </ul>
+      {% endif %}
     </div>
   </div>
 </div>
 
 <div class="container">
-  <h4><strong>Onboarding Options</strong></h4>
-  {% if page.onboard and page.onboard != empty  %}
-  <p>{{ page.onboardDescription }}</p>
+  {% if page.contentStyle != "unstructured" %}
+    <h4><strong>Onboarding Options</strong></h4>
+    {% if page.onboard and page.onboard != empty  %}
+    <p>{{ page.onboardDescription }}</p>
+    {% else %}
+    Not Applicable
+    {% endif %}
+
+    {% if page.onboard contains "API Access" %}
+    <h5> <img class="img-fluid mr-3" src="{{ site.baseurl }}/assets/images/key.svg" alt="components"> <strong>API Access
+        through GETOK</strong></h5>
+    <div class="feature-card">
+      <div class="card">
+        <div class="card-header">
+          {{ page.title }} ({{ page.name }})
+        </div>
+        <div class="card-body">
+          <div class="row no-gutters">
+            <div class="col-sm-3">API Capability</div>
+            <div class="col-sm-9">{{ content }}</div>
+          </div>
+          <div class="row no-gutters">
+            <div class="col-sm-3">API Review</div>
+            <div class="col-sm-9">
+              {% if page.urls.docs or page.urls.postman %}
+              {% if page.urls.docs %}
+              <a href="{{ page.urls.docs }}" target="_blank">Specification
+                <i class="fas fa-external-link-square-alt"></i>
+              </a>
+              {% endif %}
+              {% if page.urls.postman %}
+              <br /> <br />
+              <a href="{{ page.urls.postman }}" target="_blank" download>Postman Collection
+                <i class="fas fa-download"></i>
+              </a>
+              {% endif %}
+              {% if page.urls.postmanHelp %}
+              <br /> <br />
+              <a href="{{ page.urls.postmanHelp }}" target="_blank" download>Postman Collection Help
+                <i class="fas fa-download"></i>
+              </a>
+              {% endif %}
+              {% else %}
+              Not Applicable
+              {% endif %}
+            </div>
+          </div>
+          <div class="row no-gutters">
+            <div class="col-sm-3">GitHub</div>
+            <div class="col-sm-9">
+              {% if page.urls.docs %}
+              <a href="{{ page.urls.github }}" target="_blank">Repository
+                <i class="fas fa-external-link-square-alt"></i>
+              </a>
+              {% else %}
+              Not Applicable
+              {% endif %}
+            </div>
+          </div>
+          <div class="row no-gutters">
+            <div class="col-sm-3">See in Action</div>
+            <div class="col-sm-9">
+              {% if page.urls.showcase %}
+              <a href="{{ page.urls.showcase }}" target="_blank">Showcase App
+                <i class="fas fa-external-link-square-alt"></i>
+              </a>
+              <hr>
+              {{ page.showcaseDescription }}
+              {% else %}
+              Not Applicable
+              {% endif %}
+            </div>
+          </div>
+        </div>
+      </div>
+      {% include common/getokBtn.html %}
+    </div>
+    {% endif %}
+
+    {% if page.onboard contains "DockerHub" %}
+    <h5> <img class="img-fluid mr-3" src="{{ site.baseurl }}/assets/images/Docker.svg" alt="Docker"> <strong>DockerHub
+        @bcgovimage</strong></h5>
+    {% include common/dockerTable.html param=page %}
+    {% endif %}
+
+    {% if page.onboard contains "NPM" %}
+    <h5> <img class="img-fluid mr-3" src="{{ site.baseurl }}/assets/images/npm.svg" alt="npm"> <strong>NPM
+        @bcgovimage</strong></h5>
+    {% include common/npmTable.html param=page %}
+    {% endif %}
+
+    {% if page.onboard contains "Hosted Service" %}
+    <h5> <img class="img-fluid mr-3" src="{{ site.baseurl }}/assets/images/cloud.svg" alt="Hosted Service"><strong>Hosted Service</strong></h5>
+    <div class="feature-card">
+      <div class="card">
+        <div class="card-header">
+          {{ page.title }} ({{ page.name }})
+        </div>
+        <div class="card-body">
+          <div class="row no-gutters">
+            <div class="col-sm-3">Feature List</div>
+            <div class="col-sm-9">{{ content }}</div>
+          </div>
+          {% if page.urls.fider %}
+          <div class="row no-gutters">
+            <div class="col-sm-3">Feedback</div>
+            <div class="col-sm-9">
+              <a href="{{ page.urls.fider }}" target="_blank">Post your ideas, leave a comment or vote on what CHEFS features we should build next
+                <i class="fas fa-external-link-square-alt"></i>
+              </a>
+            </div>
+          </div>
+          {% endif %}
+          <div class="row no-gutters">
+            <div class="col-sm-3">Hosted URL</div>
+            <div class="col-sm-9">
+              <a href="{{ page.urls.hosted }}" target="_blank">{{ page.urls.hosted }}
+                <i class="fas fa-external-link-square-alt"></i>
+              </a>
+            </div>
+          </div>
+          <div class="row no-gutters">
+            <div class="col-sm-3">Documentation</div>
+            <div class="col-sm-9">
+              {% if page.urls.guide %}
+              <a href="{{ page.urls.guide }}" target="_blank">User Guide
+                <i class="fas fa-external-link-square-alt"></i>
+              </a>
+              {% endif %}
+            </div>
+          </div>
+
+          <div class="row no-gutters">
+            <div class="col-sm-3">GitHub</div>
+            <div class="col-sm-9">
+              <a href="{{ page.urls.github }}" target="_blank">Repository
+                <i class="fas fa-external-link-square-alt"></i>
+              </a>
+            </div>
+          </div>
+
+          <div class="row no-gutters">
+            <div class="col-sm-3">API Review</div>
+            <div class="col-sm-9">
+              {% if page.urls.docs %}
+              <a href="{{ page.urls.docs }}" target="_blank">Specification
+                <i class="fas fa-external-link-square-alt"></i>
+              </a>
+              {% endif %}
+              {% if page.urls.postman %}
+              <br /> <br />
+              <a href="{{ page.urls.postman }}" target="_blank" download>Postman Collection
+                <i class="fas fa-download"></i>
+              </a>
+              {% endif %}
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="text-center mt-5">
+        <a href="{{ page.urls.hosted}}" class="btn btn-primary" role="button"
+          aria-disabled="true">{{ page.title }}</a>
+      </div>
+    </div>
+    {% endif %}
+
+  <!-- unstructured markdown content (eg: CHEFS page)-->
   {% else %}
-  Not Applicable
-  {% endif %}
-
-  {% if page.onboard contains "API Access" %}
-  <h5> <img class="img-fluid mr-3" src="{{ site.baseurl }}/assets/images/key.svg" alt="components"> <strong>API Access
-      through GETOK</strong></h5>
-  <div class="feature-card">
-    <div class="card">
-      <div class="card-header">
-        {{ page.title }} ({{ page.name }})
-      </div>
-      <div class="card-body">
-        <div class="row no-gutters">
-          <div class="col-sm-3">API Capability</div>
-          <div class="col-sm-9">{{ content }}</div>
-        </div>
-        <div class="row no-gutters">
-          <div class="col-sm-3">API Review</div>
-          <div class="col-sm-9">
-            {% if page.urls.docs or page.urls.postman %}
-            {% if page.urls.docs %}
-            <a href="{{ page.urls.docs }}" target="_blank">Specification
-              <i class="fas fa-external-link-square-alt"></i>
-            </a>
-            {% endif %}
-            {% if page.urls.postman %}
-            <br /> <br />
-            <a href="{{ page.urls.postman }}" target="_blank" download>Postman Collection
-              <i class="fas fa-download"></i>
-            </a>
-            {% endif %}
-            {% if page.urls.postmanHelp %}
-            <br /> <br />
-            <a href="{{ page.urls.postmanHelp }}" target="_blank" download>Postman Collection Help
-              <i class="fas fa-download"></i>
-            </a>
-            {% endif %}
-            {% else %}
-            Not Applicable
-            {% endif %}
-          </div>
-        </div>
-        <div class="row no-gutters">
-          <div class="col-sm-3">GitHub</div>
-          <div class="col-sm-9">
-            {% if page.urls.docs %}
-            <a href="{{ page.urls.github }}" target="_blank">Repository
-              <i class="fas fa-external-link-square-alt"></i>
-            </a>
-            {% else %}
-            Not Applicable
-            {% endif %}
-          </div>
-        </div>
-        <div class="row no-gutters">
-          <div class="col-sm-3">See in Action</div>
-          <div class="col-sm-9">
-            {% if page.urls.showcase %}
-            <a href="{{ page.urls.showcase }}" target="_blank">Showcase App
-              <i class="fas fa-external-link-square-alt"></i>
-            </a>
-            <hr>
-            {{ page.showcaseDescription }}
-            {% else %}
-            Not Applicable
-            {% endif %}
-          </div>
-        </div>
-      </div>
+    <div class="unstructured-content">
+      {{ content }}
     </div>
-    {% include common/getokBtn.html %}
-  </div>
   {% endif %}
-
-  {% if page.onboard contains "DockerHub" %}
-  <h5> <img class="img-fluid mr-3" src="{{ site.baseurl }}/assets/images/Docker.svg" alt="Docker"> <strong>DockerHub
-      @bcgovimage</strong></h5>
-  {% include common/dockerTable.html param=page %}
-  {% endif %}
-
-  {% if page.onboard contains "NPM" %}
-  <h5> <img class="img-fluid mr-3" src="{{ site.baseurl }}/assets/images/npm.svg" alt="npm"> <strong>NPM
-      @bcgovimage</strong></h5>
-  {% include common/npmTable.html param=page %}
-  {% endif %}
-
-  {% if page.onboard contains "Hosted Service" %}
-  <h5> <img class="img-fluid mr-3" src="{{ site.baseurl }}/assets/images/cloud.svg" alt="Hosted Service"><strong>Hosted Service</strong></h5>
-  <div class="feature-card">
-    <div class="card">
-      <div class="card-header">
-        {{ page.title }} ({{ page.name }})
-      </div>
-      <div class="card-body">
-        <div class="row no-gutters">
-          <div class="col-sm-3">Feature List</div>
-          <div class="col-sm-9">{{ content }}</div>
-        </div>
-        {% if page.urls.fider %}
-        <div class="row no-gutters">
-          <div class="col-sm-3">Feedback</div>
-          <div class="col-sm-9">
-            <a href="{{ page.urls.fider }}" target="_blank">Post your ideas, leave a comment or vote on what CHEFS features we should build next
-              <i class="fas fa-external-link-square-alt"></i>
-            </a>
-          </div>
-        </div>
-        {% endif %}
-        <div class="row no-gutters">
-          <div class="col-sm-3">Hosted URL</div>
-          <div class="col-sm-9">
-            <a href="{{ page.urls.hosted }}" target="_blank">{{ page.urls.hosted }}
-              <i class="fas fa-external-link-square-alt"></i>
-            </a>
-          </div>
-        </div>
-        <div class="row no-gutters">
-          <div class="col-sm-3">Documentation</div>
-          <div class="col-sm-9">
-            {% if page.urls.guide %}
-            <a href="{{ page.urls.guide }}" target="_blank">User Guide
-              <i class="fas fa-external-link-square-alt"></i>
-            </a>
-            {% endif %}
-          </div>
-        </div>
-
-        <div class="row no-gutters">
-          <div class="col-sm-3">GitHub</div>
-          <div class="col-sm-9">
-            <a href="{{ page.urls.github }}" target="_blank">Repository
-              <i class="fas fa-external-link-square-alt"></i>
-            </a>
-          </div>
-        </div>
-
-        <div class="row no-gutters">
-          <div class="col-sm-3">API Review</div>
-          <div class="col-sm-9">
-            {% if page.urls.docs %}
-            <a href="{{ page.urls.docs }}" target="_blank">Specification
-              <i class="fas fa-external-link-square-alt"></i>
-            </a>
-            {% endif %}
-            {% if page.urls.postman %}
-            <br /> <br />
-            <a href="{{ page.urls.postman }}" target="_blank" download>Postman Collection
-              <i class="fas fa-download"></i>
-            </a>
-            {% endif %}
-          </div>
-        </div>
-      </div>
-    </div>
-    <div class="text-center mt-5">
-      <a href="{{ page.urls.hosted}}" class="btn btn-primary" role="button"
-        aria-disabled="true">{{ page.title }}</a>
-    </div>
-  </div>
-  {% endif %}
-
 </div>

--- a/_sass/pages.scss
+++ b/_sass/pages.scss
@@ -86,16 +86,8 @@ h2 .mascot{
   }
 }
 
-/* Style specific to the chefs service page */
-ul.feature-list {
-  padding-left: 1rem;
-  p {
-    margin-bottom: 1rem;
-  }
-}
-
-/* Style specific to the onboarding pages */
-.onboarding-content {
+/* content styles */
+.unstructured-content, .onboarding-content, .team-content {
   h4, h5, h6 {
     font-weight: bold;
   }
@@ -108,6 +100,26 @@ ul.feature-list {
     margin-top: 3rem;
     margin-bottom: 3rem;
   }
+  ul {
+    margin-bottom: 1.5rem;
+  }
+  a {
+    color: $blue-text-light;
+  }
+}
+
+/* Style specific to the 'unstructured' service pages (eg: chefs) */
+.unstructured-content {
+  p {
+    margin-bottom: 1rem;
+  }
+  li {
+    margin-bottom: .5rem;
+  }
+}
+
+/* Style specific to the onboarding pages */
+.onboarding-content {
   .feature-card .onboard-table-desc {
     display: none;
   }
@@ -124,19 +136,5 @@ ul.feature-list {
   }
   strong {
     color: $blue-text;
-  }
-}
-
-.onboarding-content, .team-content {
-  h4, h5, h6 {
-    font-weight: bold;
-  }
-  h4 {
-    font-size: 1.25rem;
-    color: $blue-text;
-    margin-bottom: 1.25rem;
-  }
-  a {
-    color: $blue-text-light;
   }
 }

--- a/collections/_services/chefs.md
+++ b/collections/_services/chefs.md
@@ -7,22 +7,64 @@ title: Common Hosted Form Service
 version: ''
 order: 3
 description: >-
-   At last! A user-friendly, hosted service for teams to create and publish their own web forms.   Complex form designs, custom access control, secure and highly available - made simple and maintained by the Common Services team and available for your next web form project.
+   CHEFS is a drag and drop hosted web form service that allows teams to create and publish their forms. With CHEFS, you can make secure forms with complex layouts. You can also manage who can access your form and assign admin roles to your team.
+descriptionLinks:
+  - link:
+      url: https://chefs.nrs.gov.bc.ca/app/login
+      text: Log in to CHEFS
+  - link:
+      url: https://chefs.nrs.gov.bc.ca/app/#video
+      text: Watch a tour of CHEFS features
+  - link:
+      url: https://github.com/bcgov/common-hosted-form-service/wiki
+      text: Review CHEFS documentation
+contentStyle: unstructured
 onboard: ['Hosted Service']
 onboardDescription: We provide a <em>Hosted Service</em> as well as documented <em>open-source code</em> for hosting your own form service.
 urls:
   hosted: https://chefs.nrs.gov.bc.ca/app/
   github: https://github.com/bcgov/common-hosted-form-service
   docs: https://chefs.nrs.gov.bc.ca/app/api/v1/docs
-  guide: https://github.com/bcgov/common-hosted-form-service/wiki/User-Guide
+  guide: https://github.com/bcgov/common-hosted-form-service/wiki
   fider: https://chefs-fider.apps.silver.devops.gov.bc.ca/
 pictures:
   icon: cheffy.svg
   header: chefs.svg
 ---
-- **User-friendly form designer** - Drag and Drop form components onto your form; Export and import your form design templates
-- **Form data review** - View and export form submission data
-- **Access controls** - Choose who can access your forms, secured with IDIR (and more options coming soon)
-- **Team management** - Configure role-based access for your team to manage forms and review submissions
-- **Notifications** - Receive Emails when your forms are submitted; Provide form respondents with email receipts
-- **Configurable form actions** - Configure form actions and custom components like the <a href="https://www.orgbook.gov.bc.ca/en/home" target="_blank">BC Orgbook</a>
+
+#### Options for getting started with CHEFS
+
+The Common Services Showcase (CSS) Team at the Ministry of Environment and Climate Change supports CHEFS and makes it available to all B.C. Government employees and their contractors.
+
+We have different ways you can use CHEFS in your projects:
+
+###### Hosted service
+
+If you have an IDIR, you can log in and start building forms right now with our drag and drop interface.
+
+- [Log into CHEFS to get started](https://chefs.nrs.gov.bc.ca/app){:target="_blank"}
+
+[Follow our quick start guide](https://github.com/bcgov/common-hosted-form-service/wiki/Quick-Start-Guide){:target="_blank"} to get you going. You can also review our [help documentation](https://github.com/bcgov/common-hosted-form-service/wiki){:target="_blank"} for answers to more detailed questions.
+
+###### API
+
+If you have an application with a form interface, you can connect to CHEFS through our API.
+
+- [Review our API specifications](https://chefs.nrs.gov.bc.ca/app/api/v1/docs){:target="_blank"}
+
+###### Self-hosted
+
+If you want to host your own version of CHEFS, you can start by:
+
+- Reading the project [README file](https://github.com/bcgov/common-hosted-form-service/blob/master/README.md){:target="_blank"} to learn about what you'll need
+- Downloading the code from our [GitHub repository](https://github.com/bcgov/common-hosted-form-service){:target="_blank"}.
+
+#### Connecting with the Common Services Showcase team
+
+We are always interested in learning about what feature we should add next. If you have a suggestion, you can post your ideas, leave a comment or vote on our [Fider board](https://chefs-fider.apps.silver.devops.gov.bc.ca/){:target="_blank"}.
+
+You also can reach out to us through:
+
+- Our [CHEFS Support channel](https://teams.microsoft.com/l/channel/19%3a34b9d4b4deb54eebaa9be8bc1ccf02f7%40thread.tacv2/CHEFS?groupId=bef8086f-20c7-43a4-bd07-29ce764e818c&tenantId=6fdb5200-3d0d-4a8a-b036-d3685e359adc){:target="_blank"}
+- Find developer support on our [Rocket.Chat channel](https://chat.developer.gov.bc.ca/channel/nr-common-services-showcase){:target="_blank"} #nr-common-services-showcase
+- Email: [nr.commonserviceshowcase@gov.bc.ca](mailto:nr.commonserviceshowcase@gov.bc.ca){:target="_blank"}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

redesign of CHEFS service page on CSS 'catalog' website.
review UI here: https://timcsaky.github.io/common-service-showcase/services/chefs.html
old design: https://bcgov.github.io/common-service-showcase/services/chefs.html

David proposed the content changes here: The new content can be found here: https://apps.nrs.gov.bc.ca/int/confluence/pages/viewpage.action?pageId=109189056

The site is built using Jekyll templates/yaml files.(https://idratherbewriting.com/documentation-theme-jekyll/mydoc_yaml_tutorial.html)
I've tried to keep the extend service.html layout template. 
I did experiment with a new template (something like service_unstructured.html) but it didnt seem necessary.

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have added necessary documentation (if appropriate)
- [x] I built and run locally to ensure no styles or formats break (if applicable)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
